### PR TITLE
switched API key because the old one had expired

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,6 +1,6 @@
 const pf = new petfinder.Client({
-	apiKey: "HB4E0LPBodtgXJlBVOYvZSDaxgGSCA7Li7Eq6tqb6uVDRfzAp4",
-	secret: "ACCq1YmJ2XzZxT6WrvbSU9voepnbCllw0NmSF363"
+	apiKey: "xFBAu7j4v4mKSyXNLQEMJfwcK2c8QzPqNCzhEpqFRUc8lUANP5",
+	secret: "Y1cVOMkc2Pkry9cYXPpR9fUfSCYVaBUdia2XJaiV"
 });
 
 


### PR DESCRIPTION
Our old API key expired so I used my own and now it works.